### PR TITLE
Adjusting number

### DIFF
--- a/Avoider/src/Avoid_Barrier.py
+++ b/Avoider/src/Avoid_Barrier.py
@@ -19,24 +19,24 @@ class SelfDrive:
         print("left : ", left)
         print("right : ", right)
         
-        if front > 0.2 or front == 0.0:
+        if front > 0.25 or front == 0.0:
             turtle_vel.linear.x = 0.15
         else:
             turtle_vel.linear.x = 0.0
-            if left < 0.2 or left != 0:
-                if right < 0.2:
+            if left < 0.25 or left != 0:
+                if right < 0.25:
                     turtle_vel.angular.z = -1.5
                 else:
                     turtle_vel.angular.z = 1.5
-            elif right < 0.2 or right != 0:
-                if left < 0.2:
+            elif right < 0.25 or right != 0:
+                if left < 0.25:
                     turtle_vel.angular.z = 1.5
                 else:
                     turtle_vel.angular.z = -1.5
-        if left < 0.2 and left != 0:
+        if left < 0.25 and left != 0:
             turtle_vel.linear.x = 0
             turtle_vel.angular.z = -0.5
-        if right < 0.2 and right != 0:
+        if right < 0.25 and right != 0:
             turtle_vel.linear.x = 0
             turtle_vel.angular.z = 0.5
         


### PR DESCRIPTION
처음 장애물 피하는 코드에서 거리가 너무 가까워 장애물과 충돌가능성이 있어서 수치를 조정합니다.
![2021-12-14-101130_1024x768_scrot](https://user-images.githubusercontent.com/94097702/145915016-82b7c0f8-1e97-47ae-b3cf-2addf984247f.png)
인식거리를 0.2에서 0.25로 수치를 변경하였고, 가상환경을 통해 빌드성공하여 터미널에서 코드실행을 한 결과 이전보다 더 안정적으로 장애물을 피할 수 있었습니다. 또 두 장애물 사이의 폭 35cm의 공간을 이전보다 더 매끄럽게 통과했습니다.